### PR TITLE
license file, docs for prices route

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,14 @@
+The MIT License (MIT)
+
+Copyright (c) 2016, Julius Tens
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,29 @@
+# db-prices-rest
+
+A public HTTP REST API, exposing a clean interface to query the Deutsche Bahn Sparpreise API.
+
+[![dependency status](https://img.shields.io/david/juliuste/db-prices-rest.svg)](https://david-dm.org/juliuste/db-prices-rest)
+[![dev dependency status](https://img.shields.io/david/dev/juliuste/db-prices-rest.svg)](https://david-dm.org/juliuste/db-prices-rest#info=devDependencies)
+[![MIT License](https://img.shields.io/badge/license-MIT-black.svg)](https://opensource.org/licenses/MIT)
+
+## Installation
+
+```bash
+git clone https://github.com/juliuste/db-prices-rest.git
+cd db-prices-rest
+npm install --production
+```
+
+## Usage
+
+Adapt `config/default.json` to your needs and run `npm start`.
+
+## Similar Projects
+
+- [db-prices](https://github.com/juliuste/db-prices/) – "Find the cheapest routes using the DB Sparpreise API."
+- [db-hafas-rest](https://github.com/juliuste/db-hafas-rest/) – "DB Hafas REST API"
+- [db-stations](https://github.com/derhuerst/db-stations/) – "A list of DB stations."
+
+## Contributing
+
+If you found a bug, want to propose a feature or feel the urge to complain about your life, feel free to visit [the issues page](https://github.com/juliuste/db-prices-rest/issues).

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 A public HTTP REST API, exposing a clean interface to query the Deutsche Bahn Sparpreise API.
 
+The public endpoint is available at `https://db-prices.juliuste.de`.
+
 [![dependency status](https://img.shields.io/david/juliuste/db-prices-rest.svg)](https://david-dm.org/juliuste/db-prices-rest)
 [![dev dependency status](https://img.shields.io/david/dev/juliuste/db-prices-rest.svg)](https://david-dm.org/juliuste/db-prices-rest#info=devDependencies)
 [![MIT License](https://img.shields.io/badge/license-MIT-black.svg)](https://opensource.org/licenses/MIT)
@@ -17,6 +19,27 @@ npm install --production
 ## Usage
 
 Adapt `config/default.json` to your needs and run `npm start`.
+
+
+## `GET /`
+
+Output from [`require('db-prices')()`](https://github.com/juliuste/db-prices)
+
+- `from`: **Required.** Station id. (see [db-stations](https://github.com/derhuerst/db-stations/))
+- `to`: **Required.** Station id. (see [db-stations](https://github.com/derhuerst/db-stations/))
+- `date`: When? UNIX timestamp or [`moment`-parsable string](http://momentjs.com/docs/#/parsing/). Default: now.
+- `class`: 1st class or 2nd class? Default: `2`.
+- `noICETrains`: Default: `false`.
+- `transferTime`: Minimum, in minutes. Default: `0`.
+- `duration`: Search for routes in the next `n` minutes. Default: `1440` (1 day).
+- `preferFastRoutes`: Default: `true`.
+- `travellers`: Default: `JSON.stringify([{bc: 0, typ: 'E', alter: 30}])`.
+
+`Content-Type`: `application/json`
+
+```shell
+curl 'https://db-prices.juliuste.de/?from=8096003&to=8000261'
+```
 
 ## Similar Projects
 


### PR DESCRIPTION
Also, consider a) giving the [`travellers` option](https://github.com/derhuerst/db-prices-rest/blob/2b123e45262c7f25b06bbd4fe2720fa8cdfebcf5/prices.js#L36) English keys and b) making it more URL-friendly. I think something like this would be nice:

`…?travellers=adult|bahncard:25|age:30,child|age:8`
